### PR TITLE
Check git commit and push

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,11 @@ service cloud.firestore {
       match /wallet/{document} {
         allow create, read, write, delete: if request.auth.uid == userId;
       }
+      // --- preferences Subcollection ---
+      // Stores per-user preferences such as notifications
+      match /preferences/{document} {
+        allow create, read, write, delete: if request.auth.uid == userId;
+      }
       // --- private wins Subcollection (per-user quarter/final wins) ---
       match /wins/{winId} {
         // Users can read their own wins; server (Admin SDK) writes


### PR DESCRIPTION
Add Firestore security rules for user preferences to fix errors on the notifications page.

The notifications page was encountering errors because the Firestore rules lacked access to `users/{userId}/preferences/*`, preventing signed-in users from reading and writing their notification preferences. This PR adds the necessary `allow create, read, write, delete` rules for this path.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f158603-39b5-4d5a-a871-2c02ac478ce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f158603-39b5-4d5a-a871-2c02ac478ce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

